### PR TITLE
Reorganize _data directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,11 @@ A handful of files need to be updated to better customize your Chapter's webpage
     - `title`
     - `description`
     - `url`
-    - `twitter username`
-- `_data/copy.yaml` Update this file with the name and description of your Chapter. 
-- `_data/blog.yml` Basic information about the blog authors, in most cases this is the name and social media links of the Chapter.
-- `_data/nav.yml` This file contains both the header and footer bars on the webpage, and will be added to every post or page made in the above section. Example values are provided from DSA National.  
+- `_data/blog.yml`: Basic information about the blog author
+- `_data/copy.yaml`: The `welcome` is the big text shown in the center of the landing page. The `about` is shown  both below the `welcome` on landing page and in the footer in every page.
+- `_data/nav.yml`: This file contains both the header and footer bars on the webpage, and will be added to every post or page on the site. The header links should change based on the content you have. The footer links likely don't need to change.
+- `_data/owner.yml`: Contains information about the chapter. Currently, only the name is used. It acts as the title in the header and footer of every page.
+- `_data/social.yml`: Contains information for all social media links and contact information.
 
 See [the Peninsula DSA's GitHub repo](https://github.com/peninsuladsa-ntc/peninsuladsa-ntc.github.io) for an example website.
 
@@ -128,3 +129,4 @@ rvm --default use 2.7.2
 
 * Instructions on how to maintain and update pages with GitHub Editor vs Desktop
 * Project website DNS name
+* The `post.html` layout always uses the first author in `blog.yml`, so there cannot be multiple authors. When this is fixed, we'll need to revisit where to store social media info for each of the authors and how it is accessed in `_layouts/post.html`.

--- a/_config.yml
+++ b/_config.yml
@@ -18,17 +18,8 @@ description: "Homepage for our DSA Chapter"
 url: # site url e.g. "https://dsachapter.github.io"
 baseurl: "" # the subpath of your site, e.g. "/blog"
 author: DSA
-twitter:
-  username: dsachapter # should be site's username
-  card: summary
 logo: assets/images/smalllogo.png # PNG is SEO friendly
-# use below when there are social links for site
-#social:
-#  name: Mani Kumar
-#  links:
-#    - https://twitter.com/dsachapter
-#    - https://www.linkedin.com/in/dsachapter/
-#    - https://github.com/dsachapter
+
 # site verifications,
 webmaster_verifications:
   google: # 1234

--- a/_data/blog.yml
+++ b/_data/blog.yml
@@ -3,22 +3,3 @@ authors:
   - name: "DSA Chapter"
     headline: # byline? 
     avatar: #"awesome_author.svg" # display_picture.jpg
-    follow:
-    - label: "Facebook"
-      icon: "fab fa-fw fa-facebook"
-      url: "https://www.facebook.com/dsachapter/"
-    - label: "Twitter"
-      icon: "fab fa-fw fa-twitter"
-      url: "https://twitter.com/dsachapter"
-    - label: "Instagram"
-      icon: "fab fa-fw fa-instagram"
-      url: "https://www.instagram.com/dsachapter/"
-
-# blog post share links
-share:
-  - label: "Facebook"
-    icon: "fab fa-fw fa-facebook"
-    url: # link
-  - label: "Twitter"
-    icon: "fab fa-fw fa-twitter-square"
-    url: # link

--- a/_data/copy.yml
+++ b/_data/copy.yml
@@ -1,4 +1,4 @@
 global:
-  - about: "<b>This is a starter website available for any DSA Chapter.</b> Democratic socialists believe both the economy and society should be run democratically to meet human needs, not to make profits for the wealthy. Throughout San Mateo County, from South San Francisco to Pacifica to East Palo Alto, our chapter fights for the good of the many, not the few."
-  - welcome: "Welcome to a DSA chapter website!"
-  - welcome-image: ""
+  about: "<b>This is a starter website available for any DSA Chapter.</b> Democratic socialists believe both the economy and society should be run democratically to meet human needs, not to make profits for the wealthy. Throughout San Mateo County, from South San Francisco to Pacifica to East Palo Alto, our chapter fights for the good of the many, not the few."
+  welcome: "Welcome to a DSA chapter website!"
+  welcome-image: ""

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -12,28 +12,8 @@ header:
 
 # footer links
 footer:
-  - owner: "DSA Chapter"
-    url: # link if any
-    description: # tool tip for your url
-    bio: "This is your chapter of the Democratic Socialists of America" # short bio
-    address: "PO Box 1234 New York, NY 12345" # address or region
-  - social:
-    - label: "Facebook"
-      icon: "fab fa-fw fa-facebook"
-      url: "https://www.facebook.com/dsachapter/"
-    - label: "Twitter"
-      icon: "fab fa-fw fa-twitter-square"
-      url: "https://twitter.com/dsachapter"
-    - label: "Instagram"
-      icon: "fab fa-fw fa-instagram"
-      url: "https://www.instagram.com/dsachapter/"
-    - label: "GitHub"
-      icon: "fab fa-fw fa-github"
-      url: "https://github.com/dsachapter"
-    - label: "Email"
-      icon: "fa fa-envelope"
-      url: "mailto:dsachapter@gmail.com"
-  - feed:
+  # Social media links are in `social.yml` so they aren't duplicated
+  feed:
     - label: "Sitemap"
       icon: "fas fa-sitemap"
       url: "/sitemap.xml"

--- a/_data/owner.yml
+++ b/_data/owner.yml
@@ -1,0 +1,9 @@
+name: "DSA Chapter"
+# link if any
+url: 
+# tool tip for your url
+description: 
+# short bio
+bio: "This is your chapter of the Democratic Socialists of America"
+# address or region
+address: "PO Box 1234 New York, NY 12345" 

--- a/_data/social.yml
+++ b/_data/social.yml
@@ -1,0 +1,51 @@
+facebook: &facebook
+  label: "Facebook"
+  icon: "fab fa-fw fa-facebook"
+  url: "https://www.facebook.com/dsachapter/"
+  username: dsachapter
+
+twitter: &twitter
+  label: "Twitter"
+  icon: "fab fa-fw fa-twitter-square"
+  url: "https://twitter.com/dsachapter"
+  username: dsachapter
+
+instagram: &instagram
+  label: "Instagram"
+  icon: "fab fa-fw fa-instagram"
+  url: "https://www.instagram.com/dsachapter/"
+  username: dsachapter
+
+github: &github
+  label: "GitHub"
+  icon: "fab fa-fw fa-github"
+  url: "https://github.com/dsachapter"
+  username: dsachapter
+
+email: &email
+  label: "Email"
+  icon: "fa fa-envelope"
+  url: "mailto:dsachapter@gmail.com"
+
+# We use the above links in different combinations in 
+# different places in the site. Making lists in the manner
+# below allows us to define the above strings once.
+
+# This list appears in the footer of every page
+footer:
+  - *facebook
+  - *twitter
+  - *instagram
+  - *github
+  - *email
+
+# This list appears in the dropdown of every blog post
+follow:
+  - *facebook
+  - *twitter
+  - *instagram
+
+# I don't see where this gets used yet
+share:
+  - *facebook
+  - *twitter

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,25 +1,25 @@
-{% assign owner = site.data.nav.footer[0] %}
-{% assign social = site.data.nav.footer[1] %}
-{% assign feed = site.data.nav.footer[2] %}
-{% assign about = site.data.copy.global[0] %}
+{% assign owner = site.data.owner %}
+{% assign social = site.data.social.footer %}
+{% assign feed = site.data.nav.footer.feed %}
+{% assign about = site.data.copy.global.about %}
 
 <footer class="page-footer">
     <div class="page-footer-owner">
         <div class="container">
             <div class="row my-3">
                 <div class="col-md-12">
-                    <h2>{{ owner.owner }} <span class="float-right">🌹</span></h1>
+                    <h2>{{ owner.name }} <span class="float-right">🌹</span></h1>
                 </div>
             </div>
             <div class="row my-3">
                 <div class="col-md-8 col-sm-12">
-                    <p class="my-3">{{ about.about }}</p>
+                    <p class="my-3">{{ about }}</p>
                 </div>
                 <div class="col-md-2 col-sm-12">
                     <h4 class="text-red m-0">Socials</h3>
                     <!-- Social media links -->
                     <ul class="my-3">
-                        {% for so_link in social.social %}
+                        {% for so_link in social %}
                         <li>
                             {% if so_link.url %}
                             <i class="{{ so_link.icon }}"></i><a href="{{ so_link.url }}">{{ so_link.label }}</a>
@@ -33,7 +33,7 @@
                 <div class="col-md-2 col-sm-12">
                     <h4 class="text-red m-0">Sitemap</h3>
                     <ul class="my-3">
-                        {% for fd_link in feed.feed %}
+                        {% for fd_link in feed %}
                         <li>
                             <i class="{{ fd_link.icon }}"></i> <a href="{{ fd_link.url | relative_url }}">{{ fd_link.label }}</a>
                         </li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,11 +1,11 @@
-{% assign owner = site.data.nav.footer[0] %}
+{% assign owner = site.data.owner %}
 
 <header class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm">
   <nav class="container">
     <!-- site home -->
     <a class="navbar-brand" href="{{ '/' | absolute_url }}">
       <img class="my-auto mr-2" src="{{ site.logo | relative_url }}" alt="{{ site.title }} logo" height="32" width="32">
-      <b>{{ owner.owner }}</b>
+      <b>{{ owner.name }}</b>
     </a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarColor01"
       aria-controls="navbarColor01" aria-expanded="false" aria-label="Toggle navigation">

--- a/_includes/social-share.html
+++ b/_includes/social-share.html
@@ -1,5 +1,5 @@
 {%- assign share_title = "Share on" -%}
-{%- assign twitter = site.data.blog.social_share[1] -%}
+{%- assign twitter = site.data.social.twitter -%}
 
 <div class="my-3">
     <h5 class="m-0 p-0">{{ share_title }}</h5>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -51,7 +51,7 @@ layout: default
             <button class="btn btn-primary dropdown-toggle" type="button" id="followMenuButton"
               data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Follow</button>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="followMenuButton">
-              {% for follow in blog_author.follow %}
+              {% for follow in site.data.social.follow %}
               <a class="dropdown-item pb-2" href="{{ follow.url }}"><i
                   class="{{ follow.icon }}"></i>{{ follow.label }}</a>
               {% endfor %}

--- a/index.html
+++ b/index.html
@@ -2,21 +2,19 @@
 layout: default
 ---
 
-{% assign about = site.data.copy.global[0] %}
-{% assign welcome = site.data.copy.global[1] %}
+{% assign about = site.data.copy.global.about %}
+{% assign welcome = site.data.copy.global.welcome %}
 
 <div class="container my-5">
   <div class="row">
     <div class="col-md-6 col-sm-12">
-      <h1>{{ welcome.welcome }}</h1>
+      <h1>{{ welcome }}</h1>
       <hr class="large" />
-      <p>{{ about.about }}</p>
+      <p>{{ about }}</p>
       <a href="/about" class="btn btn-secondary">Read More <i class="fa fa-arrow-right"></i></a>
     </div>
     <div class="col-md-6 col-sm-12 text-right">
-	    <a href="/">
       <img src="assets/images/ece-4-all-ssf-volunteers-at-campaign-launch-2022-01-15.jpg" width="90%" height="auto" alt="Dozens of volunteers at the Pre-school for all campaign launch!" />
-	    </a>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
This PR reorganizes the `_data` directory to make it easier to keep track of an edit. The primary purpose is to put social media information in a single file to reduce the amount of editing and prevent the information from desyncing.

I also improved the access patterns in the HTML so there is no longer magic number indexing into lists (like `site.data.nav.footer[1]`) nor repeated names (like `{{ about.about }}`).