### PR TITLE
Use remote theme for local building

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,12 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-gem "lone-wolf-theme"
+gem "jekyll-remote-theme"
+gem "jekyll-paginate"
+gem "jekyll-sitemap"
+gem "jekyll-gist"
+gem "jekyll-feed"
+gem "jekyll-seo-tag"
+gem "jemoji"
+gem "jekyll-include-cache"
+gem "jekyll-data"

--- a/_config.yml
+++ b/_config.yml
@@ -130,6 +130,7 @@ plugins:
   - jekyll-seo-tag
   - jemoji
   - jekyll-include-cache
+  - jekyll-remote-theme
 
 # mimic GitHub Pages with --safe
 whitelist:
@@ -140,6 +141,7 @@ whitelist:
   - jekyll-seo-tag
   - jemoji
   - jekyll-include-cache
+  - jekyll-remote-theme
 
 # HTML Compression
 # - http://jch.penibelst.de/


### PR DESCRIPTION
Uses the remote theme plugin to grab the lone-wolf-theme for local building.

You can install a theme in your `Gemfile` and specify it in your `_config.yml` and it will build locally. But, if it isn't one of the themes supported by GitHub (https://pages.github.com/themes/), GitHub will not build your site for you.

You can specify a `remote_theme` in your `_config.yml` and as long as it is a public repo on GitHub, GitHub will build your site using it. But, your site will not build locally if this is all you do.

I thought you could specify both `theme` and `remote_theme` in your `_config.yml`, but it turns out you can't. GitHub will see the `theme: ` line first and fail since we're not using one of their supported themes. I then came across this Jekyll plugin (https://github.com/benbalter/jekyll-remote-theme) which lets you install your remote theme locally so you can build locally. As a result, we don't list our theme in the `Gemfile`.

The big caveat is that I can't actually test that this will still work when GitHub builds our site...

A side effect of this change is that I had to add all of the plugins we specify in our `_config.yml` to the `Gemfile` in order to get local building to work. I didn't have to do this before. I don't actually know if we're using any of these plugins, so that's something to investigate.